### PR TITLE
Update sphere generation algorithm

### DIFF
--- a/src/DummyLevel.lua
+++ b/src/DummyLevel.lua
@@ -29,7 +29,7 @@ end
 
 ---Generates a new sphere color.
 ---@return integer
-function DummyLevel:newSphereColor()
+function DummyLevel:newSphereColor(curColor)
 	return self.colors[math.random(1, #self.colors)]
 end
 

--- a/src/SphereChain.lua
+++ b/src/SphereChain.lua
@@ -27,7 +27,8 @@ function SphereChain:new(path, deserializationTable)
 
 		self.sphereGroups = {}
 		self.generationAllowed = self.path.spawnRules.type == "continuous"
-		self.generationColor = self.path:newSphereColor()
+		-- not sure how to do this one.
+		self.generationColor = self.path:newSphereColor(0)
 
 
 		-- Generate the first group.
@@ -232,8 +233,17 @@ function SphereChain:generateSphere()
 	-- Add a new sphere.
 	self:getLastSphereGroup():pushSphereBack(self.generationColor)
 	-- Each sphere: check whether we should generate a fresh new color (chance is colorStreak).
-	if math.random() >= self.path.colorStreak then
-		self.generationColor = self.path:newSphereColor()
+	-- If this exceeds max singles the same color will be forced, and if it exceeds max clump then a new color will be forced.
+
+	if (math.random() >= self.path.colorStreak and self.path.curSingles < self.path.maxSingles+1) or self.path.curClump >= self.path.maxClumps then
+		self.generationColor = self.path:newSphereColor(self.generationColor)
+		self.path.curClump = 1
+		self.path.curSingles = self.path.curSingles + 1
+		--_Log:printt("Cur Singles", "-> " .. self.path.curSingles)
+	else	
+		self.path.curClump = self.path.curClump + 1
+		self.path.curSingles = 0
+		--_Log:printt("Cur Clumps", "-> " .. self.path.curClump)
 	end
 end
 


### PR DESCRIPTION
- maxSingles determines how many single balls can appear in a row before the next one must be the same color.
- maxClumps determines the max number of same colored balls in a row before the next ball must be a different color.
- Allows food effects to adjust these parameters.
- Added optional parameters `maxSingles` and `maxClumps` to the level json.
- newSphereColor adjusted so the same color cannot be generated again.