### PR TITLE
Add speed bonuses

### DIFF
--- a/games/ZumaBlitzRemake/config/powers/speed_shot.json
+++ b/games/ZumaBlitzRemake/config/powers/speed_shot.json
@@ -4,6 +4,6 @@
     "levels": [
         {"additiveMultiplier": 0.1},
         {"additiveMultiplier": 0.2, "speedBonusMultiplier": 1.6},
-        {"additiveMultiplier": 0.3, "speedBonusMultiplier": 3.0}
+        {"additiveMultiplier": 0.3, "speedBonusMultiplier": 3.5}
     ]
 }

--- a/games/ZumaBlitzRemake/config/powers/speed_shot.json
+++ b/games/ZumaBlitzRemake/config/powers/speed_shot.json
@@ -3,7 +3,7 @@
     "type": "shotSpeedMultiplier",
     "levels": [
         {"additiveMultiplier": 0.1},
-        {"additiveMultiplier": 0.2},
-        {"additiveMultiplier": 0.3}
+        {"additiveMultiplier": 0.2, "speedBonusMultiplier": 1.6},
+        {"additiveMultiplier": 0.3, "speedBonusMultiplier": 3.0}
     ]
 }

--- a/src/Level.lua
+++ b/src/Level.lua
@@ -1256,7 +1256,9 @@ function Level:serialize()
 		lightningStormTime = self.lightningStormTime,
 		destroyedSpheres = self.destroyedSpheres,
 		paths = self.map:serialize(),
-		lost = self.lost
+		lost = self.lost,
+		speedBonus = self.speedBonus,
+		speedTimer = self.speedTimer
 	}
 	for i, shotSphere in ipairs(self.shotSpheres) do
 		table.insert(t.shotSpheres, shotSphere:serialize())
@@ -1302,6 +1304,9 @@ function Level:deserialize(t)
 	self.shotLastHotFrogBall = t.shotLastHotFrogBall
 	self.multiplier = t.multiplier
 	self.lost = t.lost
+	-- ingame counters
+	self.speedBonus = t.speedBonus or 0
+	self.speedTimer = t.speedTimer or 0
 	-- Utils
 	self.controlDelay = t.controlDelay
 	self.finish = t.finish

--- a/src/Level.lua
+++ b/src/Level.lua
@@ -439,6 +439,12 @@ function Level:updateLogic(dt)
 		_Game.uiManager:executeCallback("levelLost")
 		self.ended = true
 	end
+
+	-- Other variables, such as the speed timer
+	-- timer will not tick down when under hot frog.
+	if self.speedTimer > 0 and self.blitzMeter < 1 then
+		self.speedTimer = self.speedTimer - dt
+	end
 end
 
 
@@ -1056,6 +1062,10 @@ function Level:reset()
 	self.targets = 0
     self.time = 0
 	self.stateCount = 0
+
+	-- add in current speedbonus
+	self.speedBonus = 0
+	self.speedTimer = 0
 
     self.target = nil
 	if _MathAreKeysInTable(self, "targetFrequency", "type") == "seconds" then

--- a/src/Shooter.lua
+++ b/src/Shooter.lua
@@ -623,8 +623,22 @@ function Shooter:getShootingSpeed()
     -- src: http://bchantech.dreamcrafter.com/zumablitz/spiritanimals.php
     local eagleSpeedShot = (_Game:getCurrentProfile():getActiveMonument() == "spirit_eagle" and 0.75) or 0
     -- TODO: What's the order of speed shot multipliers?
+
+    -- modify the speed bonus based on the blitz meter
+    -- Food will affect this by an amount. 
+    
+    local foodSpeedBonusVel_add = _MathAreKeysInTable(_Game:getCurrentProfile():getEquippedFoodItemEffects(), "speedUpShotsTotalIncrease") or 0
+    local speedBonusShotSpeed = math.max(_Game.session.level.blitzMeter - 0.5,0) * (1600 + foodSpeedBonusVel_add*2)
+
+    local finalSpeed =  self.config.shootSpeed + (self.config.shootSpeed * powerMultiplier) + foodSpeedShot_add + (self.config.shootSpeed * eagleSpeedShot) + speedBonusShotSpeed
+    finalSpeed = finalSpeed * (1 + foodSpeedShot_mult)
+
+    -- _Log:printt("final speed", "-> " ..  finalSpeed)
+
     -- Would it also be ideal to set a max speed bonus cap?
-    return self.config.shootSpeed + (self.config.shootSpeed * powerMultiplier) + (self.config.shootSpeed * foodSpeedShot_mult) + foodSpeedShot_add + (self.config.shootSpeed * eagleSpeedShot)
+    finalSpeed = math.min(finalSpeed, 2000)
+
+    return finalSpeed
 end
 
 

--- a/src/SphereGroup.lua
+++ b/src/SphereGroup.lua
@@ -711,8 +711,11 @@ function SphereGroup:matchAndDeleteEffect(position, effect)
 	self.map.level.speedTimer = 2.75
 		_Log:printt("Speed bonus", "-> " ..  self.map.level.speedBonus)
 
+		local speedShot = _Game:getCurrentProfile():getEquippedPower("speed_shot")
+		local powerSpeedBonusMultiplier = (speedShot and speedShot:getCurrentLevelData().speedBonusMultiplier) or 1
+
 	-- Calculate and grant score.
-	local score = length * (10 + self.map.level.speedBonus)
+	local score = length * (10 + (self.map.level.speedBonus * powerSpeedBonusMultiplier))
 	if boostCombo then
         if self.map.level.combo > 5 then
             score = score + 100 + ((self.map.level.combo - 6) * 10)

--- a/src/SphereGroup.lua
+++ b/src/SphereGroup.lua
@@ -698,8 +698,21 @@ function SphereGroup:matchAndDeleteEffect(position, effect)
 		_Game:playSound(comboSoundParams.name, comboSoundParams.pitch, pos)
 	end
 
+	-- speed bonus - max x12
+	-- TODO: Variables for food that may affect the speed timer, and speed bonus, as well as max increments allowed
+	if self.map.level.speedTimer <= 0 then
+		self.map.level.speedBonus = 0
+	end
+
+	if self.map.level.speedBonus < (12*10) then
+		self.map.level.speedBonus = self.map.level.speedBonus + 10
+	end
+	
+	self.map.level.speedTimer = 2.75
+		_Log:printt("Speed bonus", "-> " ..  self.map.level.speedBonus)
+
 	-- Calculate and grant score.
-	local score = length * 10
+	local score = length * (10 + self.map.level.speedBonus)
 	if boostCombo then
         if self.map.level.combo > 5 then
             score = score + 100 + ((self.map.level.combo - 6) * 10)


### PR DESCRIPTION
  - Matching starts a speed bonus counter that grants additional points for making matches quickly, but resets after 2.75 seconds without a match while not in hot frog mode.
  - Shot speed now increases based on the hot frog meter after 50%
  - Max shot speed capped at 2000
  - Super Speed and Warp Speed powers now multiplies Speed Bonus by 1.6x and 3.5x respectively