### PR TITLE
Gray balls/7th color and extra color and its behavior from modded ZR

### DIFF
--- a/games/ZumaBlitzRemake/config/color_generators/danger.json
+++ b/games/ZumaBlitzRemake/config/color_generators/danger.json
@@ -3,6 +3,7 @@
     "select_chance": 0.25,
     "paths_in_danger_only": true,
     "colors": [
+        -7,
         1,
         2,
         3,
@@ -13,6 +14,7 @@
     ],
     "fallback": 0,
     "colors_remove_if_nonexistent": [
+        -7,
         1,
         2,
         3,

--- a/games/ZumaBlitzRemake/config/color_generators/danger.json
+++ b/games/ZumaBlitzRemake/config/color_generators/danger.json
@@ -14,7 +14,6 @@
     ],
     "fallback": 0,
     "colors_remove_if_nonexistent": [
-        -7,
         1,
         2,
         3,

--- a/games/ZumaBlitzRemake/config/color_generators/default.json
+++ b/games/ZumaBlitzRemake/config/color_generators/default.json
@@ -14,6 +14,7 @@
         "type": "random",
         "hasToExist": false,
         "colors": [
+            -7,
             1,
             2,
             3,

--- a/games/ZumaBlitzRemake/config/shooters/default.json
+++ b/games/ZumaBlitzRemake/config/shooters/default.json
@@ -45,6 +45,9 @@
         "y": 32
     },
     "nextBallSprites": {
+        "-7": {
+            "sprite": "sprites/game/shooters/next_ball_0.json"
+        },
         "-3": {
             "sprite": "sprites/game/shooters/next_ball_0.json"
         },

--- a/games/ZumaBlitzRemake/config/shooters/frogatar_basic.json
+++ b/games/ZumaBlitzRemake/config/shooters/frogatar_basic.json
@@ -45,6 +45,9 @@
         "y": 32
     },
     "nextBallSprites": {
+        "-7": {
+            "sprite": "sprites/game/shooters/next_ball_0.json"
+        },
         "-3": {
             "sprite": "sprites/game/shooters/next_ball_0.json"
         },

--- a/games/ZumaBlitzRemake/config/shooters/spirit_eagle.json
+++ b/games/ZumaBlitzRemake/config/shooters/spirit_eagle.json
@@ -45,6 +45,9 @@
         "y": 21
     },
     "nextBallSprites": {
+        "-7": {
+            "sprite": "sprites/game/shooters/next_ball_0.json"
+        },
         "-3": {
             "sprite": "sprites/game/shooters/next_ball_0.json"
         },

--- a/games/ZumaBlitzRemake/config/shooters/spirit_turtle.json
+++ b/games/ZumaBlitzRemake/config/shooters/spirit_turtle.json
@@ -42,6 +42,9 @@
         "y": 34
     },
     "nextBallSprites": {
+        "-7": {
+            "sprite": "sprites/game/shooters/next_ball_0.json"
+        },
         "-3": {
             "sprite": "sprites/game/shooters/next_ball_0.json"
         },

--- a/games/ZumaBlitzRemake/config/spheres/sphere_-1.json
+++ b/games/ZumaBlitzRemake/config/spheres/sphere_-1.json
@@ -16,6 +16,7 @@
     },
     "hitSound": "sound_events/sphere_hit_normal.json",
     "matches": [
+        -7,
         -1,
         1,
         2,

--- a/games/ZumaBlitzRemake/config/spheres/sphere_-7.json
+++ b/games/ZumaBlitzRemake/config/spheres/sphere_-7.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "../../../../schemas/config/Sphere.json",
+	"spriteRollingSpeed": 1.15,
+    "sprite": "sprites/game/ball_4_cb.json",
+    "destroyParticle": "particles/collapse_wild.json",
+    "powerupSprites": {
+        "timeball": "sprites/game/time_ball_4_cb.json",
+        "multiplier": "sprites/game/multiplier_ball_4_cb.json"
+    },
+    "color": {
+        "r": 0.5,
+        "g": 0.5,
+        "b": 0.5
+    },
+    "interchangeable": true,
+    "shootBehavior": {
+        "type": "normal"
+    },
+    "shootSound": "sound_events/sphere_shoot_normal.json",
+    "hitBehavior": {
+        "type": "normal"
+    },
+    "hitSound": "sound_events/sphere_hit_normal.json",
+    "matches": [
+        -1,
+        -7
+    ],
+    "matchFont": "fonts/score0.json"
+}


### PR DESCRIPTION
As you probably know, the Zuma's Revenge way of handling extra colors is gimmicky; extra colors don't appear on the shooter, which means you need to either use powerups or make combos as in [this YouTube video](https://www.youtube.com/watch?v=tNHVMrIA_pY).

However, the behavior here I proposed is inexact; they now appear on the shooter only if either there's no generetable sphere types on the board, or is in the danger zone, so it is a nerf that should make it easier to deal with "matches like normal but don't appear on the shooter" nonsense in Zuma's Revenge, especially with extra colors.